### PR TITLE
Section styles: removed bg colors and added border

### DIFF
--- a/src/components/CharlasSection.astro
+++ b/src/components/CharlasSection.astro
@@ -4,33 +4,36 @@ import Charlas from './Charlas.astro';
 const temas = [
   {
     titulo: 'Introducción a la Web3',
-    descripcion: 'Una mirada accesible a las tecnologías descentralizadas y cómo pueden cambiar el futuro.',
+    descripcion:
+      'Una mirada accesible a las tecnologías descentralizadas y cómo pueden cambiar el futuro.',
     ponente: 'María González',
     foto: 'https://randomuser.me/api/portraits/women/44.jpg',
   },
   {
     titulo: 'Ciberseguridad para Devs',
-    descripcion: 'Tips prácticos para proteger tus proyectos desde el inicio del desarrollo.',
+    descripcion:
+      'Tips prácticos para proteger tus proyectos desde el inicio del desarrollo.',
     ponente: 'Carlos Pérez',
     foto: 'https://randomuser.me/api/portraits/men/32.jpg',
   },
   {
     titulo: 'AI y Ética',
-    descripcion: 'Exploramos los dilemas éticos del uso de la inteligencia artificial en productos digitales.',
+    descripcion:
+      'Exploramos los dilemas éticos del uso de la inteligencia artificial en productos digitales.',
     ponente: 'Lucía Romero',
     foto: 'https://randomuser.me/api/portraits/women/68.jpg',
   },
 ];
-
 ---
 
-<section id="charlas" class="py-12 bg-gray-50">
+<section
+  id="charlas"
+  class="py-12 rounded-2xl shadow-md border border-purple-200"
+>
   <h2 class="text-3xl font-bold text-center mb-2">
     Charlas del Evento
     <br />
-    <h3 class="text-2xl font-bold text-center mb-6">
-      🎤📋
-    </h3>
+    <h3 class="text-2xl font-bold text-center mb-6">🎤📋</h3>
   </h2>
 
   <div class="flex flex-wrap justify-center gap-8">

--- a/src/components/ColaboradorSection.astro
+++ b/src/components/ColaboradorSection.astro
@@ -31,7 +31,7 @@ const colaboradores = [
 ];
 ---
 
-<section id="colaboradores" class="py-12 bg-gray-100">
+<section id="colaboradores" class="py-12">
   <h2 class="text-3xl font-bold text-center mb-2">
     Colaboradores
     <br />

--- a/src/components/PostsSection.astro
+++ b/src/components/PostsSection.astro
@@ -1,7 +1,7 @@
 ---
-import PostCard from './PostCard.astro';
-import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+import PostCard from './PostCard.astro';
 
 type Post = CollectionEntry<'posts'>;
 
@@ -11,7 +11,7 @@ const posts: Post[] = (await getCollection('posts'))
   .slice(0, 3);
 ---
 
-<section id="blog" class="py-12 bg-white rounded-2xl shadow-md border border-gray-100">
+<section id="blog" class="py-12 rounded-2xl shadow-md border border-purple-200">
   <div class="max-w-4xl mx-auto px-6">
     <div class="text-center mb-12">
       <h2 class="text-3xl font-bold text-gray-800 mb-2">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,11 @@
 ---
 import CharlasSection from '@/components/CharlasSection.astro';
+import ColaboradorSection from '@/components/ColaboradorSection.astro';
 import Organizadores from '@/components/Organizadores.astro';
 import Ponentes from '@/components/Ponentes.astro';
 import PostsSection from '@/components/PostsSection.astro';
 import Layout from '@/layouts/Layout.astro';
 import Agenda from '../components/agenda.astro';
-import ColaboradorSection from '@/components/ColaboradorSection.astro';
 ---
 
 <Layout title="GDG Aranjuez | DevFest 2025">
@@ -53,7 +53,7 @@ import ColaboradorSection from '@/components/ColaboradorSection.astro';
     <!-- Detalles Evento -->
     <section
       id="comunidad"
-      class="bg-white rounded-2xl shadow-md p-8 mb-16 border border-gray-100"
+      class="rounded-2xl shadow-md p-8 mb-16 border border-purple-400"
     >
       <div class="grid md:grid-cols-2 gap-8 items-center">
         <div>
@@ -104,8 +104,8 @@ import ColaboradorSection from '@/components/ColaboradorSection.astro';
     <!-- Seccion de Ponentes -->
     <Ponentes />
 
-      <!-- Seccion de Colaboradores -->
-      <ColaboradorSection/>
+    <!-- Seccion de Colaboradores -->
+    <ColaboradorSection />
 
     <!-- Countdown -->
     <section
@@ -125,7 +125,7 @@ import ColaboradorSection from '@/components/ColaboradorSection.astro';
 
       <!-- Agenda del evento -->
       <section
-        class="bg-white rounded-2xl shadow-md p-8 mb-16 border border-gray-100"
+        class="bg-white rounded-2xl shadow-md p-8 mb-16 border border-purple-200"
       >
         <Agenda />
       </section>


### PR DESCRIPTION
I removed background colors from some components that were clashing with the main layout on the index page.
- Before
![Captura de pantalla 2025-06-03 095623](https://github.com/user-attachments/assets/a7d81f38-2db5-4a09-8100-77792e7ae6a1)
![Captura de pantalla 2025-06-03 095750](https://github.com/user-attachments/assets/ca603ff7-20c0-426f-87d7-e26e6ab9f28d)
- After
![Captura de pantalla 2025-06-03 102843](https://github.com/user-attachments/assets/e4f0936e-5210-469d-bd55-1cfc9eac8cf1)
![Captura de pantalla 2025-06-03 102900](https://github.com/user-attachments/assets/9a4b6fa3-aed8-4500-bdd7-e8beb1343308)

Added subtle borders to certain sections just to keep things visually separated — nothing functional, just for layout clarity.

These are purely visual changes and don’t affect how anything works.

I’ll open another issue/PR later to adjust styles for dark/light mode once this is merged.