### PR TITLE
Refactor agenda items in AgendaDevFest.astro to use placeholders for time, titles, and speakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # 🌟 WEB GDG ARANJUEZ
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/src/components/AgendaDevFest.astro
+++ b/src/components/AgendaDevFest.astro
@@ -1,66 +1,69 @@
 ---
+// Agenda completamente provisional - todos los datos son placeholders
 const agenda = [
   {
-    hora: '10:00',
-    titulo: 'Apertura y Bienvenida.',
-    ponente: 'Equipo GDG Aranjuez.',
+    hora: 'HH:MM',
+    titulo: 'Actividad por confirmar',
+    ponente: 'Pendiente',
     perfil: '',
   },
   {
-    hora: '10:30',
-    titulo: 'Novedades en inteligencia artificial.',
-    ponente: 'María López.',
+    hora: 'HH:MM',
+    titulo: 'Actividad por confirmar',
+    ponente: 'Pendiente',
     perfil: '',
   },
   {
-    hora: '11:30',
-    titulo: 'Desarrollo web con Astro.',
-    ponente: 'Carlos García.',
+    hora: 'HH:MM',
+    titulo: 'Actividad por confirmar',
+    ponente: 'Pendiente',
     perfil: '',
   },
   {
-    hora: '13:00',
-    titulo: 'Lunch & networking.',
-    ponente: '',
+    hora: 'HH:MM',
+    titulo: 'Actividad por confirmar',
+    ponente: 'Pendiente',
     perfil: '',
   },
   {
-    hora: '14:30',
-    titulo: 'Serverless con Firebase.',
-    ponente: 'Lucía Torres.',
-    perfil: '',
-  },
-  {
-    hora: '16:00',
-    titulo: 'Panel: Futuro de la tecnología en España.',
-    ponente: 'Varios ponentes.',
-    perfil: '',
-  },
-  {
-    hora: '17:30',
-    titulo: 'Cierre y sorteos.',
-    ponente: 'Equipo GDG Aranjuez.',
+    hora: 'HH:MM',
+    titulo: 'Actividad por confirmar',
+    ponente: 'Pendiente',
     perfil: '',
   },
 ];
 ---
+
 <section
   id="agenda"
   class="bg-blue-100 text-gray-900
-         dark:bg-slate-800 dark:text-gray-100
-         font-sans rounded-2xl shadow-md p-10 mb-6 mt-12
-         border border-blue-100 dark:border-slate-500
-         max-w-3xl mx-auto scroll-mt-24"
+        dark:bg-slate-800 dark:text-gray-100
+        font-sans rounded-2xl shadow-md p-10 mb-6 mt-12
+        border border-blue-100 dark:border-slate-500
+        max-w-3xl mx-auto scroll-mt-24"
 >
-  <h2 class="text-3xl font-mono font-bold  text-blue-800 dark:text-blue-300 mb-6 text-center">
+  <h2
+    class="text-3xl font-mono font-bold text-blue-800 dark:text-blue-300 mb-6 text-center"
+  >
     Agenda 2025
   </h2>
+  <div
+    class="bg-yellow-100 dark:bg-yellow-900/30 p-4 rounded-lg mb-6 text-center"
+  >
+    <p class="text-yellow-800 dark:text-yellow-200">
+      La agenda definitiva será publicada próximamente
+    </p>
+  </div>
   <ul class="space-y-6">
     {
       agenda.map((item) => (
-        <li class="grid grid-cols-[80px_1fr] gap-x-6 items-start text-lg
-                   border-b border-gray-400 dark:border-gray-600 pb-4 last:border-b-0">
-          <time class="font-mono text-blue-800 dark:text-blue-300 pl-4">{item.hora}</time>
+        <li
+          class="grid grid-cols-[80px_1fr] gap-x-6 items-start text-lg
+                  border-b border-gray-400 dark:border-gray-600 pb-4 last:border-b-0"
+        >
+          <time class="font-mono text-blue-800 dark:text-blue-300 pl-4">
+            {item.hora}
+          </time>
           <div>
             <div class="font-semibold">{item.titulo}</div>
             {item.ponente && (

--- a/src/components/Charlas.astro
+++ b/src/components/Charlas.astro
@@ -22,9 +22,7 @@ const altTexto = `Foto de ${ponente}`;
   >
     {descripcion}
   </p>
-  <p
-    class="text-m font-medium text-gray-900 dark:text-gray-300"
-  >
+  <p class="text-m font-medium text-gray-900 dark:text-gray-300">
     🙋🏻 {ponente}
   </p>
 </article>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -171,16 +171,14 @@
       menu.classList.toggle('hidden');
     });
 
-  // seleccionar enlaces y el botón de modo oscuro
-const links = menu.querySelectorAll('a, #theme-toggle');
-links.forEach((link) => {
-  link.addEventListener('click', () => {
-    if (window.innerWidth < 1024) {
-      menu.classList.add('hidden');
-    }
-  });
-});
+    // seleccionar enlaces y el botón de modo oscuro
+    const links = menu.querySelectorAll('a, #theme-toggle');
+    links.forEach((link) => {
+      link.addEventListener('click', () => {
+        if (window.innerWidth < 1024) {
+          menu.classList.add('hidden');
+        }
+      });
+    });
   }
 </script>
-
-


### PR DESCRIPTION
Adds a provisional agenda to ``AgendaDevFest.astro`` using clearly defined placeholder values while waiting for the final schedule confirmation.

### Changes

* Adds placeholder items to the agenda:
  * `hora: 'HH:MM'`
  * `titulo: 'Actividad por confirmar'`
  * `ponente: 'Pendiente'`
* Adds a highlighted notice: **“La agenda definitiva será publicada próximamente”**.
* Maintains the layout, styling, and responsiveness.

###  Notes

* This structure allows to keep the design intact while we wait for official details.
* The placeholders make it clear that content is provisional and can be easily updated later.

![Captura de pantalla 2025-06-16 155615](https://github.com/user-attachments/assets/b8799795-f9a4-4f15-825a-31ee9058dee9)