### PR TITLE
Refactor charlas items in CharlasSection.astro to use placeholders for titles, descriptions and speakers 

### DIFF
--- a/src/components/AgendaDevFest.astro
+++ b/src/components/AgendaDevFest.astro
@@ -59,11 +59,7 @@ const agenda = [
       agenda.map((item) => (
         <li
           class="grid grid-cols-[80px_1fr] gap-x-6 items-start text-lg
-<<<<<<< 129-add-placeholders-to-charlassection-unconfirmed-content
-                   border-b border-gray-400 dark:border-gray-600 pb-4 last:border-b-0"
-=======
                   border-b border-gray-400 dark:border-gray-600 pb-4 last:border-b-0"
->>>>>>> dev
         >
           <time class="font-mono text-blue-800 dark:text-blue-300 pl-4">
             {item.hora}


### PR DESCRIPTION
Replace all mock data in `CharlasSection` with placeholder content:

* Titles now use: `"Título pendiente"`
* Descriptions use: `"Descripción pendiente"`
* Speaker names use: `"Ponente pendiente"`
* Photos replaced with `https://via.placeholder.com/150` as a generic placeholder

This change reflects that the talks are not yet confirmed.

![Captura de pantalla 2025-06-17 000206](https://github.com/user-attachments/assets/fdf61d4c-3b69-4208-a466-6ad353da1c94)
