### PR TITLE
Update collaborator details in ColaboradorSection.astro to use placeholders

### DIFF
--- a/src/components/ColaboradorSection.astro
+++ b/src/components/ColaboradorSection.astro
@@ -3,29 +3,30 @@ import Colaborador from './Colaborador.astro';
 
 const colaboradores = [
   {
-    nombre: 'Ana López',
-    rol: 'Diseño de branding y redes',
-    foto: 'https://randomuser.me/api/portraits/women/12.jpg',
+    nombre: 'Colaborador pendiente',
+    rol: '',
+    foto: 'https://api.dicebear.com/9.x/identicon/svg?radius=50&seed=colab1',
     redes: {
-      twitter: 'https://twitter.com/ana_lopez',
-      linkedin: 'https://www.linkedin.com/in/ana-lopez/',
+      twitter: '#',
+      linkedin: '#',
     },
   },
   {
-    nombre: 'Luis Fernández',
-    rol: 'Soporte técnico en streaming',
-    foto: 'https://randomuser.me/api/portraits/men/45.jpg',
+    nombre: 'Colaborador pendiente',
+    rol: '',
+    foto: 'https://api.dicebear.com/9.x/identicon/svg?radius=50&seed=colab2',
     redes: {
-      github: 'https://github.com/luisfdev',
-      linkedin: 'https://www.linkedin.com/in/luisfernandez/',
+      twitter: '#',
+      linkedin: '#',
     },
   },
   {
-    nombre: 'Carla Méndez',
-    rol: 'Moderación de comunidad',
-    foto: 'https://randomuser.me/api/portraits/women/60.jpg',
+    nombre: 'Colaborador pendiente',
+    rol: '',
+    foto: 'https://api.dicebear.com/9.x/identicon/svg?radius=50&seed=colab3',
     redes: {
-      twitter: 'https://twitter.com/carlicode',
+      twitter: '#',
+      linkedin: '#',
     },
   },
 ];


### PR DESCRIPTION
Replaces the current collaborator details with temporary placeholder values and automatically generated avatar images using [Dicebear](https://www.dicebear.com/) ensures the section remains visually complete and functional while we wait for the final collaborator information.

* The `colaboradores` array now includes generic names (e.g., "Colaborador pendiente") and empty role fields.
* Avatars are generated using DiceBear’s *identicon* style to provide unique and consistent visuals.
* Social media links have been replaced with `"#"` as placeholders.

![Captura de pantalla 2025-06-17 115231](https://github.com/user-attachments/assets/a1212cf8-808c-4f64-9947-b4f780d1a6bd)
