### PR TITLE
Reorder sponsors by tier

### DIFF
--- a/src/components/Patrocinadores.astro
+++ b/src/components/Patrocinadores.astro
@@ -1,6 +1,6 @@
 ---
 const sponsors = {
-  Gold: [
+  Platinum: [
     {
       name: 'Ayuntamiento Aranjuez',
       logo: 'patrocinadores/aranjuez-firma_negro-01.webp',
@@ -16,7 +16,7 @@ const sponsors = {
       },
     },
   ],
-  Platinum: [
+  Gold: [
     {
       name: 'Adopta Un Junior',
       logo: '/patrocinadores/image-adopta-un-junior.jpg',


### PR DESCRIPTION
Reordered and relocated sponsors list and content:
Order:
1. Platinum → Ayuntamiento + Google
2. Gold → AuJ
3. Silver
4. Media Partners