### PR TITLE
Removed GDG organizer title from OrganizadoresSection

### DIFF
--- a/src/components/OrganizadoresSection.astro
+++ b/src/components/OrganizadoresSection.astro
@@ -5,7 +5,7 @@ const organizadores = [
   /* Lista de organizadores con nombre, cargo, foto, y link a redes */
   {
     nombre: 'Ángeles Vázquez',
-    cargo: 'GDG Organizer\nEventbrite',
+    cargo: 'Eventbrite',
     foto: '/organizadores/angeles_vazquez_parra.webp',
     redes: {
       twitter: 'https://twitter.com/avazpar',
@@ -15,7 +15,7 @@ const organizadores = [
   },
   {
     nombre: 'Juanje Cilla',
-    cargo: 'GDG Organizer\nHiberus',
+    cargo: 'Hiberus',
     foto: '/organizadores/juanje_cilla_ugarte.webp',
     redes: {
       linkedin:
@@ -24,7 +24,7 @@ const organizadores = [
   },
   {
     nombre: 'Saúl Díaz',
-    cargo: 'GDG Organizer\nEventbrite',
+    cargo: 'Eventbrite',
     foto: '/organizadores/saul_diaz.webp',
     redes: {
       twitter:
@@ -34,7 +34,7 @@ const organizadores = [
   },
   {
     nombre: 'Patricia Tarazaga',
-    cargo: 'GDG Organizer',
+    cargo: 'Eventbrite',
     foto: '/organizadores/patricia_tarazaga.webp',
     redes: {
       linkedin: 'https://www.linkedin.com/in/patricia-tarazaga/',
@@ -42,7 +42,7 @@ const organizadores = [
   },
   {
     nombre: 'Daniel Brinzei',
-    cargo: 'GDG Organizer',
+    cargo: 'Zartis',
     foto: '/organizadores/daniel_brinzei.jpeg',
     redes: {
       linkedin: 'https://www.linkedin.com/in/daniel-brinzei/',


### PR DESCRIPTION
As the title says, GDG organizer is removed from "cargo" and replaced with only the companies the organizers are working at.