### PR TITLE
Hide C4P button

### DIFF
--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -122,8 +122,8 @@ import Countdown from './Countdown.astro';
           stroke-width="2"></path>
       </svg>
     </button>
-
-    <!-- Call for Papers Button -->
+    <!-- 
+    <!-- Call for Papers Button (hidden)
     <button
       id="cfp-button"
       aria-label="Botón para Call for Papers"
@@ -154,6 +154,6 @@ import Countdown from './Countdown.astro';
           stroke-width="2"
           stroke-linecap="round"></path>
       </svg>
-    </button>
+    </button> -->
   </div>
 </section>


### PR DESCRIPTION
The C4P button is hidden - inside a comment.
Why inside a comment? So we can save it as a template for future projects, in my opinion, but we can just delete it if the team prefers so.